### PR TITLE
Optional __version__.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,6 +118,14 @@ but can be configured in your package's :file:`pyproject.toml` file:
     [tool.attribution]
     name = "foobar"
 
+Attribution automatically maintains a `__version__.py` file.
+Projects already using something like `setuptools_scm` to manage version info, can disable it set `version_file` to `false`.
+
+.. code-block:: toml
+
+    [tool.attribution]
+    version_file = false
+
 More details can be found in the `User Guide`_.
 
 .. _User Guide: https://attribution.omnilib.dev/en/stable/guide.html

--- a/attribution/main.py
+++ b/attribution/main.py
@@ -69,10 +69,13 @@ def tag_release(version: Version, message: Optional[str]) -> None:
     try:
         # XXX: This is a really hacky wall of commands
         project = Project.load()
-        version_file = Path(project.name) / "__version__.py"
-        version_file.write_text(f'__version__ = "{version}"\n')
-        sh(f"git add {version_file}")
-        sh(f"git commit -m 'Version bump v{version}'")
+
+        if project.config.get("version_file", True):
+            version_file = Path(project.name) / "__version__.py"
+            version_file.write_text(f'__version__ = "{version}"\n')
+            sh(f"git add {version_file}")
+            sh(f"git commit -m 'Version bump v{version}'")
+
         tag = Tag.create(version, message=message)
         changelog = Changelog(project).generate()
         changelog_file = Path("CHANGELOG.md")

--- a/attribution/main.py
+++ b/attribution/main.py
@@ -70,7 +70,7 @@ def tag_release(version: Version, message: Optional[str]) -> None:
         # XXX: This is a really hacky wall of commands
         project = Project.load()
 
-        if project.config.get("version_file", True):
+        if project.config.get("version_file"):
             version_file = Path(project.name) / "__version__.py"
             version_file.write_text(f'__version__ = "{version}"\n')
             sh(f"git add {version_file}")

--- a/attribution/main.py
+++ b/attribution/main.py
@@ -74,8 +74,8 @@ def tag_release(version: Version, message: Optional[str]) -> None:
             version_file = Path(project.name) / "__version__.py"
             version_file.write_text(f'__version__ = "{version}"\n')
             sh(f"git add {version_file}")
-            sh(f"git commit -m 'Version bump v{version}'")
 
+        sh(f"git commit -m 'Version bump v{version}' --allow-empty")
         tag = Tag.create(version, message=message)
         changelog = Changelog(project).generate()
         changelog_file = Path("CHANGELOG.md")

--- a/attribution/project.py
+++ b/attribution/project.py
@@ -66,7 +66,7 @@ class Project:
 
             if "tool" in pyproject and "attribution" in pyproject["tool"]:
                 config = pyproject["tool"]["attribution"]
-                config.setdefault('version_file', True)
+                config.setdefault("version_file", True)
                 name = config.get("name", "")
 
         if not name:

--- a/attribution/project.py
+++ b/attribution/project.py
@@ -66,6 +66,7 @@ class Project:
 
             if "tool" in pyproject and "attribution" in pyproject["tool"]:
                 config = pyproject["tool"]["attribution"]
+                config.setdefault('version_file', True)
                 name = config.get("name", "")
 
         if not name:

--- a/attribution/tests/project.py
+++ b/attribution/tests/project.py
@@ -87,14 +87,26 @@ name = "fizzbuzz"
                 project = Project.load()
                 cwd_mock.assert_called_once()
                 self.assertEqual(project.name, "fizzbuzz")
-                self.assertEqual(project.config, {"name": "fizzbuzz"})
+                self.assertEqual(project.config, {'name': 'fizzbuzz', 'version_file': True})
                 cwd_mock.reset_mock()
 
             with self.subTest("pyproject in given path"):
                 project = Project.load(td)
                 cwd_mock.assert_not_called()
                 self.assertEqual(project.name, "fizzbuzz")
-                self.assertEqual(project.config, {"name": "fizzbuzz"})
+                self.assertEqual(project.config, {'name': 'fizzbuzz', 'version_file': True})
+
+            with self.subTest("pyproject with no version_file defaults to True"):
+                pyproject.write_text(fake_pyproject.strip())
+                project = Project.load(td)
+                self.assertTrue(project.config.get("version_file"))
+                self.assertEqual(project.config, {'name': 'fizzbuzz', 'version_file': True})
+
+            with self.subTest("pyproject reads version_file"):
+                pyproject.write_text(fake_pyproject.strip() + "\nversion_file=false")
+                project = Project.load(td)
+                self.assertFalse(project.config.get("version_file"))
+                self.assertEqual(project.config, {'name': 'fizzbuzz', 'version_file': False})
 
             with self.subTest("empty pyproject"):
                 pyproject.write_text("\n")

--- a/attribution/tests/project.py
+++ b/attribution/tests/project.py
@@ -87,26 +87,34 @@ name = "fizzbuzz"
                 project = Project.load()
                 cwd_mock.assert_called_once()
                 self.assertEqual(project.name, "fizzbuzz")
-                self.assertEqual(project.config, {'name': 'fizzbuzz', 'version_file': True})
+                self.assertEqual(
+                    project.config, {"name": "fizzbuzz", "version_file": True}
+                )
                 cwd_mock.reset_mock()
 
             with self.subTest("pyproject in given path"):
                 project = Project.load(td)
                 cwd_mock.assert_not_called()
                 self.assertEqual(project.name, "fizzbuzz")
-                self.assertEqual(project.config, {'name': 'fizzbuzz', 'version_file': True})
+                self.assertEqual(
+                    project.config, {"name": "fizzbuzz", "version_file": True}
+                )
 
             with self.subTest("pyproject with no version_file defaults to True"):
                 pyproject.write_text(fake_pyproject.strip())
                 project = Project.load(td)
                 self.assertTrue(project.config.get("version_file"))
-                self.assertEqual(project.config, {'name': 'fizzbuzz', 'version_file': True})
+                self.assertEqual(
+                    project.config, {"name": "fizzbuzz", "version_file": True}
+                )
 
             with self.subTest("pyproject reads version_file"):
                 pyproject.write_text(fake_pyproject.strip() + "\nversion_file=false")
                 project = Project.load(td)
                 self.assertFalse(project.config.get("version_file"))
-                self.assertEqual(project.config, {'name': 'fizzbuzz', 'version_file': False})
+                self.assertEqual(
+                    project.config, {"name": "fizzbuzz", "version_file": False}
+                )
 
             with self.subTest("empty pyproject"):
                 pyproject.write_text("\n")

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -24,3 +24,8 @@ Options available are described as follows:
     and anywhere else the project name is displayed. Defaults to the name
     of the current working directory.
 
+.. attribute:: version_file
+
+    Boolean value [true/false] that specifies if the `Attribute` should add the file
+    `__version__.py` to the repo. Some projects are already using something like
+    `setuptools_scm` to manage version info, so it maybe redundant.


### PR DESCRIPTION
### Description
we keep track of `__version__.py` in the project namespace, this PR aims to make it optional.

Adds a default value for `version_file` to `True`
Works for `false` and `true` 

Fixes: #2 
