### PR TITLE
Option to configure a set of ignored authors

### DIFF
--- a/attribution/main.py
+++ b/attribution/main.py
@@ -4,7 +4,7 @@
 import logging
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Any, Callable, Optional
 
 import click
 import tomlkit
@@ -73,6 +73,22 @@ def init() -> None:
     project = Project.load()
     if version_file:
         VersionFile(project).write()
+
+
+@main.command("debug")
+def debug() -> None:
+    """Dump debug info about project"""
+    pprint: Callable[[Any], None]
+    try:
+        import rich
+
+        pprint = rich.print
+    except ImportError:
+        pprint = click.echo
+
+    project = Project.load()
+    pprint(f"pyproject.toml: {project.pyproject_path()}")
+    pprint(project)
 
 
 @main.command("generate")

--- a/attribution/main.py
+++ b/attribution/main.py
@@ -126,7 +126,10 @@ def tag_release(version: Version, message: Optional[str]) -> None:
 
         if project.tags:
             tag = project.tags[0]
-            git_log = sh(f"git log --reverse {tag.name}..")
+            log_cmd = ["git", "log", "--reverse", f"{tag.name}..", "--invert-grep"]
+            for author in project.config["ignored_authors"]:
+                log_cmd += [f"--author={author}"]
+            git_log = sh(*log_cmd)
             tpl += f"#\n# Changes since {tag.name}:\n#\n"
             tpl += "".join(f"# {line}\n" for line in git_log.splitlines(keepends=False))
 

--- a/attribution/project.py
+++ b/attribution/project.py
@@ -70,6 +70,7 @@ class Project:
         name = ""
         package = ""
         config: Dict[str, Any] = {
+            "ignored_authors": [],
             "version_file": True,
             "signed_tags": True,
         }
@@ -80,6 +81,22 @@ class Project:
                 config.update(pyproject["tool"]["attribution"])
                 name = config.get("name", "")
                 package = config.get("package", "")
+                ignored_authors = config.get("ignored_authors", [])
+
+                if ignored_authors:
+                    if isinstance(ignored_authors, str):
+                        config["ignored_authors"] = list(ignored_authors)
+                    elif isinstance(ignored_authors, list):
+                        for author in list(ignored_authors):
+                            if not isinstance(author, str):
+                                LOG.warning(
+                                    f"ignored_authors value {author!r} must be string"
+                                )
+                                ignored_authors.remove(author)
+                    else:
+                        LOG.warning("ignored_authors must be string or list of strings")
+                        ignored_authors = []
+                    config["ignored_authors"] = ignored_authors
 
         if not name:
             name = path.name

--- a/attribution/tests/project.py
+++ b/attribution/tests/project.py
@@ -113,6 +113,7 @@ package = "fizzbuzz"
                     {
                         "name": "fizzbuzz",
                         "package": "fizzbuzz",
+                        "ignored_authors": [],
                         "version_file": True,
                         "signed_tags": True,
                     },
@@ -128,6 +129,7 @@ package = "fizzbuzz"
                     {
                         "name": "fizzbuzz",
                         "package": "fizzbuzz",
+                        "ignored_authors": [],
                         "version_file": True,
                         "signed_tags": True,
                     },
@@ -142,6 +144,7 @@ package = "fizzbuzz"
                     {
                         "name": "fizzbuzz",
                         "package": "fizzbuzz",
+                        "ignored_authors": [],
                         "version_file": True,
                         "signed_tags": True,
                     },
@@ -156,6 +159,7 @@ package = "fizzbuzz"
                     {
                         "name": "fizzbuzz",
                         "package": "fizzbuzz",
+                        "ignored_authors": [],
                         "version_file": False,
                         "signed_tags": True,
                     },
@@ -167,7 +171,8 @@ package = "fizzbuzz"
                 cwd_mock.assert_not_called()
                 self.assertEqual(project.name, td.name)
                 self.assertEqual(
-                    project.config, {"version_file": True, "signed_tags": True}
+                    project.config,
+                    {"ignored_authors": [], "version_file": True, "signed_tags": True},
                 )
 
             with self.subTest("no pyproject"):
@@ -176,5 +181,6 @@ package = "fizzbuzz"
                 cwd_mock.assert_not_called()
                 self.assertEqual(project.name, td.name)
                 self.assertEqual(
-                    project.config, {"version_file": True, "signed_tags": True}
+                    project.config,
+                    {"ignored_authors": [], "version_file": True, "signed_tags": True},
                 )

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -16,6 +16,8 @@ following this example:
     [tool.attribution]
     name = "Project"
     package = "project"
+    ignored_authors = ["dependabot"]
+    signed_tags = true
     version_file = true
 
 These options can be added automatically by running ``attribution init`` from
@@ -37,6 +39,18 @@ Options available are described as follows:
     creating or updating the package's version file (if :attr:`version_file`
     is ``true``), and should match the top-level namespace used when importing
     your package at runtime.
+
+.. attribute:: ignored_authors
+    :type: str | list[str]
+    :value: []
+
+    List of author names (or patterns) that will be ignored and excluded when
+    showing project revisions. For example, when tagging a new release, any
+    configured authors will be excluded from the list of revisions displayed
+    as part of the message template.
+
+    This can be helpful for excluding noisy or frequent commits from automated
+    sources that aren't likely to be relevant when writing release notes.
 
 .. attribute:: signed_tags
     :type: bool

--- a/makefile
+++ b/makefile
@@ -33,8 +33,8 @@ test:
 	python -m mypy $(PKG)
 
 .PHONY: html
-html: venv
-	.venv/bin/sphinx-build -b html docs html
+html:
+	.venv/bin/sphinx-build -ab html docs html
 
 clean:
 	rm -rf build dist html README MANIFEST *.egg-info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ exclude = [
 [tool.attribution]
 name = "attribution"
 package = "attribution"
-ignore_authors = ["dependabot", "pyup.io bot"]
+ignored_authors = ["dependabot", "pyup.io bot"]
 version_file = true
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ exclude = [
 [tool.attribution]
 name = "attribution"
 package = "attribution"
+ignore_authors = ["dependabot", "pyup.io bot"]
 version_file = true
 
 [tool.coverage.run]


### PR DESCRIPTION
### Description

Adds the `tool.attribution.ignored_authors` option that takes a list of strings.
These will be passed to `git log` as authors to ignore when generating the list
of revisions between two tags, and potentially more in the future.

This will make it easy to ignore things like dependabot or pyup commits when
tagging a new release and reviewing the history of changes.

Fixes: #
